### PR TITLE
Replaced the vizapi references with api

### DIFF
--- a/appserver/static/visualizations/heatmap/src/heatmap.js
+++ b/appserver/static/visualizations/heatmap/src/heatmap.js
@@ -1,8 +1,8 @@
 define([
             'jquery',
             'underscore',
-            'vizapi/SplunkVisualizationBase',
-            'vizapi/SplunkVisualizationUtils',
+            'api/SplunkVisualizationBase',
+            'api/SplunkVisualizationUtils',
             'plotly.js'
         ],
         function(

--- a/appserver/static/visualizations/heatmap/webpack.config.js
+++ b/appserver/static/visualizations/heatmap/webpack.config.js
@@ -13,7 +13,7 @@ module.exports = {
         libraryTarget: 'amd'
     },
     externals: [
-        'vizapi/SplunkVisualizationBase',
-        'vizapi/SplunkVisualizationUtils'
+        'api/SplunkVisualizationBase',
+        'api/SplunkVisualizationUtils'
     ]
 };


### PR DESCRIPTION
The heatmap visualization is not working in Splunk v9.1.3. Changing the vizapi reference with api fixes the issue